### PR TITLE
Account for differences in equivalent gmail addresses

### DIFF
--- a/components/expired-members-remover/index.test.js
+++ b/components/expired-members-remover/index.test.js
@@ -1,8 +1,8 @@
-const { getName } = require("./index");
+const { getName, parseEmailForComparing } = require("./index");
 
 describe("all tests", () => {
   it("getName", () => {
-    test_data = [
+    const test_data = [
       { input: undefined, expected: "" },
       { input: { firstName: "", lastName: "" }, expected: "" },
       { input: { firstName: "Joe Ann", lastName: "" }, expected: "Joe" },
@@ -13,4 +13,18 @@ describe("all tests", () => {
         expect(getName(test_case.input)).toBe(test_case.expected);
     }
   });
+
+  it("parseEmails", () => {
+    const test_data = [
+      { input: "smith.jo.hn@gmail.com", expected: "smithjohn@gmail.com" },
+      { input: "smithjohn@gmail.com", expected: "smithjohn@gmail.com" },
+      { input: "smith.John@gmail.com", expected: "smithjohn@gmail.com" },
+      { input: "smithjohn@gMail.com", expected: "smithjohn@gmail.com" },
+      { input: "smith.john@outlook.com", expected: "smith.john@outlook.com" },
+    ]
+
+    for (let test_case of test_data) {
+      expect(parseEmailForComparing(test_case.input)).toBe(test_case.expected);
+    }
+  })
 });

--- a/components/membership-form-backend/package.json
+++ b/components/membership-form-backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "cross-env ENVIRONMENT=development functions-framework --target=main --signature-type=event",
+    "start": "cross-env ENVIRONMENT=development functions-framework --target=main --port=8000 --signature-type=event",
     "test": "jest",
     "deploy": "gcloud config set project utoc-membership-system-test && gcloud builds submit",
     "deploy-prod": "gcloud config set project utoc-membership-system && gcloud builds submit"


### PR DESCRIPTION
Gmail addresses with out without dots (".") are equivalent. Further, google groups will automatically transform the email to its default. Therefore, I need to remove the dots before comparing two gmail addresses.